### PR TITLE
Enable python 3.9 support in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]  # 3.9
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
-node_modules
 dist.yaml
+node_modules
+openapi.yaml

--- a/server/tox.ini
+++ b/server/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py37,py38
+envlist = py37,py38,py39
 skipsdist = True
 
 [gh-actions]
 python =
     3.7: py37
     3.8: py38
+    3.9: py39
 
 [testenv]
 deps =


### PR DESCRIPTION
Add support to Python 3.9 now that conda supports this version (up to 3.9.1)